### PR TITLE
objectType was not propagated

### DIFF
--- a/internal/broker/schema.go
+++ b/internal/broker/schema.go
@@ -179,6 +179,7 @@ func newBrokerEntity(inputs EntityInputs, isResource bool) brokerEntity[schema.S
 			pathTemplate:          inputs.PathTemplate,
 			postPathTemplate:      inputs.PostPathTemplate,
 			terraformName:         inputs.TerraformName,
+			objectType:            inputs.ObjectType,
 			identifyingAttributes: identifyingAttributes,
 			attributes:            inputs.Attributes,
 			converter:             NewObjectConverter(inputs.TerraformName, inputs.Attributes),


### PR DESCRIPTION
This allows the `solacebroker_broker` object to be used.